### PR TITLE
lsp + convenience changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "vizx",
   "displayName": "ViZX",
   "description": "Visualizer for the ZX calculus",
-  "version": "0.0.3",
-  "repository": "https://github.com/inQWIRE/VyZXViz/",
+  "version": "0.0.4",
+  "repository": "https://github.com/inQWIRE/ViZX/",
   "publisher": "inQWIRE",
   "engines": {
     "vscode": "^1.74.0"
@@ -24,12 +24,24 @@
         "title": "Render expressions with ViZX"
       },
       {
+        "command": "vizx.scaleUp",
+        "title": "Scale size of diagrams UP"
+      },
+      {
+        "command": "vizx.scaleDown",
+        "title": "Scale size of diagrams DOWN"
+      },
+      {
         "command": "vizx.lspRender",
         "title": "Render expressions with ViZX using CoqLSP information"
       },
       {
         "command": "vizx.activateRendering",
-        "title": "Activate ViZX rendering"
+        "title": "Activate ViZX automatic rendering"
+      },
+      {
+        "command": "vizx.deactivateRendering",
+        "title": "Deactivate ViZX automatic rendering"
       }
     ]
   },

--- a/src/constants/consts.ts
+++ b/src/constants/consts.ts
@@ -66,7 +66,7 @@ export function scaleUp() {
 export function scaleDown() {
   SCALE = SCALE * 0.9;
   CANVAS_WIDTH = CANVAS_WIDTH * 0.9;
-  CANVAS_HEIGHT = CANVAS_HEIGHT * 0.;
+  CANVAS_HEIGHT = CANVAS_HEIGHT * 0;
   BASE_SIZE = 1 * SCALE;
   PAD_SIZE = 0.1 * SCALE;
   PROPTO_SIZE = 0.2 * SCALE;
@@ -78,7 +78,6 @@ export function scaleDown() {
   SMALL_TEXT = (SCALE / 10).toString().concat("px");
   MEDIUM_TEXT = (SCALE / 7).toString().concat("px");
   LARGE_TEXT = (SCALE / 2).toString().concat("px");
-
 }
 
 export function setCanvasWidthHeight(wh: [number, number]) {

--- a/src/constants/consts.ts
+++ b/src/constants/consts.ts
@@ -25,26 +25,61 @@ export const COLORSWAP_TRANSFORM = "⊙";
 export const FLIP_TRANSFORM = "⥍";
 
 // SCALE = size of base square, ideally do not go below 100 or it'll be too small
-export const SCALE = 150;
-export const BASE_SIZE = 1 * SCALE;
-export const PAD_SIZE = 0.1 * SCALE;
-export const PROPTO_SIZE = 0.2 * SCALE;
-export const CAST_SIZE = 0.3 * SCALE;
-export const TEXT_PAD_SIZE = 0.08 * SCALE;
-export const DOTS_PAD_SIZE = 0.1 * SCALE;
-export const FUNC_ARG_SIZE = 0.4 * SCALE;
-export const REALLY_SMALL_TEXT_SIZE = (SCALE / 15).toString().concat("px");
-export const SMALL_TEXT_SIZE = (SCALE / 10).toString().concat("px");
-export const MEDIUM_TEXT_SIZE = (SCALE / 7).toString().concat("px");
-export const LARGE_TEXT_SIZE = (SCALE / 2).toString().concat("px");
-export const MONOSPACE_FONT = "Monospace";
-export const ARIAL_FONT = "Arial";
+export let SCALE = 100;
+export let BASE_SIZE = 1 * SCALE;
+export let PAD_SIZE = 0.1 * SCALE;
+export let PROPTO_SIZE = 0.2 * SCALE;
+export let CAST_SIZE = 0.3 * SCALE;
+export let TEXT_PAD_SIZE = 0.08 * SCALE;
+export let DOTS_PAD_SIZE = 0.1 * SCALE;
+export let FUNC_ARG_SIZE = 0.4 * SCALE;
+export let REALLY_SMALL_TEXT = (SCALE / 15).toString().concat("px");
+export let SMALL_TEXT = (SCALE / 10).toString().concat("px");
+export let MEDIUM_TEXT = (SCALE / 7).toString().concat("px");
+export let LARGE_TEXT = (SCALE / 2).toString().concat("px");
+export let MONOSPACE_FONT = "Monospace";
+export let ARIAL_FONT = "Arial";
 
 export const NUMBER_KINDS = ["realnum", "num", "numvar", "numfunc", "real01"];
 
 // yeah yeah not really a constant whatever
 export let CANVAS_WIDTH = 500;
 export let CANVAS_HEIGHT = 500;
+
+export function scaleUp() {
+  SCALE = SCALE * 1.1;
+  CANVAS_WIDTH = CANVAS_WIDTH * 1.1;
+  CANVAS_HEIGHT = CANVAS_HEIGHT * 1.1;
+  BASE_SIZE = 1 * SCALE;
+  PAD_SIZE = 0.1 * SCALE;
+  PROPTO_SIZE = 0.2 * SCALE;
+  CAST_SIZE = 0.3 * SCALE;
+  TEXT_PAD_SIZE = 0.08 * SCALE;
+  DOTS_PAD_SIZE = 0.1 * SCALE;
+  FUNC_ARG_SIZE = 0.4 * SCALE;
+  REALLY_SMALL_TEXT = (SCALE / 15).toString().concat("px");
+  SMALL_TEXT = (SCALE / 10).toString().concat("px");
+  MEDIUM_TEXT = (SCALE / 7).toString().concat("px");
+  LARGE_TEXT = (SCALE / 2).toString().concat("px");
+}
+
+export function scaleDown() {
+  SCALE = SCALE * 0.9;
+  CANVAS_WIDTH = CANVAS_WIDTH * 0.9;
+  CANVAS_HEIGHT = CANVAS_HEIGHT * 0.;
+  BASE_SIZE = 1 * SCALE;
+  PAD_SIZE = 0.1 * SCALE;
+  PROPTO_SIZE = 0.2 * SCALE;
+  CAST_SIZE = 0.3 * SCALE;
+  TEXT_PAD_SIZE = 0.08 * SCALE;
+  DOTS_PAD_SIZE = 0.1 * SCALE;
+  FUNC_ARG_SIZE = 0.4 * SCALE;
+  REALLY_SMALL_TEXT = (SCALE / 15).toString().concat("px");
+  SMALL_TEXT = (SCALE / 10).toString().concat("px");
+  MEDIUM_TEXT = (SCALE / 7).toString().concat("px");
+  LARGE_TEXT = (SCALE / 2).toString().concat("px");
+
+}
 
 export function setCanvasWidthHeight(wh: [number, number]) {
   CANVAS_WIDTH = wh[0];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,9 +4,14 @@ import * as vscode from "vscode";
 import * as parser from "./parsing/parser";
 import * as sizer from "./parsing/sizes";
 import * as coord from "./parsing/coords";
-import { boundary, setCanvasWidthHeight } from "./constants/consts";
+import { boundary, setCanvasWidthHeight, scaleUp, scaleDown } from "./constants/consts";
+import * as consts from "./constants/consts";
 import * as ast from "./parsing/ast";
 import { getCanvasHtml } from "./webview/webview";
+
+let openTabNames : String[] = [];
+let openWebview : vscode.WebviewPanel | undefined = undefined;
+
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
@@ -32,6 +37,23 @@ export function activate(context: vscode.ExtensionContext) {
     );
   });
   context.subscriptions.push(disposable);
+  disposable = vscode.commands.registerCommand("vizx.deactivateRendering", () => {
+    deactivate();
+    (vscode.window.showInformationMessage(
+      "Automatic rendering is now turned off."
+    ));
+  });
+  context.subscriptions.push(disposable);
+  disposable = vscode.commands.registerCommand("vizx.scaleUp", () => {
+    scaleUp();
+    console.log("SCALE: ", consts.SCALE, " HEIGHT: ", consts.CANVAS_HEIGHT, "WIDTH: ", consts.CANVAS_WIDTH)
+  });
+  context.subscriptions.push(disposable);
+  disposable = vscode.commands.registerCommand("vizx.scaleDown", () => {
+    scaleDown();
+    console.log("SCALE: ", consts.SCALE, " HEIGHT: ", consts.CANVAS_HEIGHT, "WIDTH: ", consts.CANVAS_WIDTH)
+  });
+  context.subscriptions.push(disposable);
 }
 
 function renderCallback(context: vscode.ExtensionContext, expr: any) {
@@ -41,14 +63,20 @@ function renderCallback(context: vscode.ExtensionContext, expr: any) {
       return;
     }
     if (expr.arg1 !== undefined) {
-      expr = expr.arg1.goals.goals[0].ty;
+      // extract correct field from lsp information
+      expr = expr.goals.goals[0].ty;
     }
     console.log("expr: ", expr);
+    if(openTabNames.includes(expr)) {
+      return;
+    }
+    openTabNames.push(expr);
     let node: ast.ASTNode;
     try {
       node = parser.parseAST(expr);
       node = sizer.addSizes(node);
       const size = sizer.determineCanvasWidthHeight(node);
+      console.log("size = ", size);
       setCanvasWidthHeight(size);
       node = coord.addCoords(node, boundary);
     } catch (e) {
@@ -57,15 +85,19 @@ function renderCallback(context: vscode.ExtensionContext, expr: any) {
       );
       return;
     }
+    if (openWebview !== undefined) {
+      openWebview.dispose();
+    }
     const panel = vscode.window.createWebviewPanel(
       "ViZX",
       `ViZX: ${expr}`,
-      vscode.ViewColumn.One,
+      vscode.ViewColumn.Three,
       {
         enableScripts: true,
         retainContextWhenHidden: true,
       }
     );
+    openWebview = panel;
     panel.webview.html = getCanvasHtml(panel, context);
     panel.webview.onDidReceiveMessage((msg) => console.log(msg));
     panel.webview.postMessage({ command: JSON.stringify(node) });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -86,6 +86,7 @@ function renderCallback(context: vscode.ExtensionContext, expr: any) {
       return;
     }
     if (openWebview !== undefined) {
+      openTabNames.filter(x => x !== openWebview!.title);
       openWebview.dispose();
     }
     const panel = vscode.window.createWebviewPanel(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,13 +4,18 @@ import * as vscode from "vscode";
 import * as parser from "./parsing/parser";
 import * as sizer from "./parsing/sizes";
 import * as coord from "./parsing/coords";
-import { boundary, setCanvasWidthHeight, scaleUp, scaleDown } from "./constants/consts";
+import {
+  boundary,
+  setCanvasWidthHeight,
+  scaleUp,
+  scaleDown,
+} from "./constants/consts";
 import * as consts from "./constants/consts";
 import * as ast from "./parsing/ast";
 import { getCanvasHtml } from "./webview/webview";
 
-let openTabNames : String[] = [];
-let openWebview : vscode.WebviewPanel | undefined = undefined;
+let openTabNames: String[] = [];
+let openWebview: vscode.WebviewPanel | undefined = undefined;
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -37,21 +42,38 @@ export function activate(context: vscode.ExtensionContext) {
     );
   });
   context.subscriptions.push(disposable);
-  disposable = vscode.commands.registerCommand("vizx.deactivateRendering", () => {
-    deactivate();
-    (vscode.window.showInformationMessage(
-      "Automatic rendering is now turned off."
-    ));
-  });
+  disposable = vscode.commands.registerCommand(
+    "vizx.deactivateRendering",
+    () => {
+      deactivate();
+      vscode.window.showInformationMessage(
+        "Automatic rendering is now turned off."
+      );
+    }
+  );
   context.subscriptions.push(disposable);
   disposable = vscode.commands.registerCommand("vizx.scaleUp", () => {
     scaleUp();
-    console.log("SCALE: ", consts.SCALE, " HEIGHT: ", consts.CANVAS_HEIGHT, "WIDTH: ", consts.CANVAS_WIDTH)
+    console.log(
+      "SCALE: ",
+      consts.SCALE,
+      " HEIGHT: ",
+      consts.CANVAS_HEIGHT,
+      "WIDTH: ",
+      consts.CANVAS_WIDTH
+    );
   });
   context.subscriptions.push(disposable);
   disposable = vscode.commands.registerCommand("vizx.scaleDown", () => {
     scaleDown();
-    console.log("SCALE: ", consts.SCALE, " HEIGHT: ", consts.CANVAS_HEIGHT, "WIDTH: ", consts.CANVAS_WIDTH)
+    console.log(
+      "SCALE: ",
+      consts.SCALE,
+      " HEIGHT: ",
+      consts.CANVAS_HEIGHT,
+      "WIDTH: ",
+      consts.CANVAS_WIDTH
+    );
   });
   context.subscriptions.push(disposable);
 }
@@ -67,7 +89,7 @@ function renderCallback(context: vscode.ExtensionContext, expr: any) {
       expr = expr.goals.goals[0].ty;
     }
     console.log("expr: ", expr);
-    if(openTabNames.includes(expr)) {
+    if (openTabNames.includes(expr)) {
       return;
     }
     openTabNames.push(expr);
@@ -86,7 +108,7 @@ function renderCallback(context: vscode.ExtensionContext, expr: any) {
       return;
     }
     if (openWebview !== undefined) {
-      openTabNames.filter(x => x !== openWebview!.title);
+      openTabNames.filter((x) => x !== openWebview!.title);
       openWebview.dispose();
     }
     const panel = vscode.window.createWebviewPanel(

--- a/src/parsing/parser.ts
+++ b/src/parsing/parser.ts
@@ -403,10 +403,10 @@ function applySpider(args: [Token, ast.Num, ast.Num, ast.Num]): ast.ASTNode {
 
 ZXSTACKCOMPOSE.setPattern(
   lrec_sc(
-    alt(ZXBASETERM, ZXCAST),
+    alt(ZXBASETERM, ZXCAST, ZXNSTACK),
     seq(
       alt(tok(lex.TokenKind.Stack), tok(lex.TokenKind.Compose)),
-      alt(ZXBASETERM, ZXCAST)
+      alt(ZXBASETERM, ZXCAST, ZXNSTACK)
     ),
     applyStackCompose
   )
@@ -550,7 +550,7 @@ function applyPropTo(args: [ast.ASTNode, Token, ast.ASTNode]): ast.ASTNode {
 ASTNODE.setPattern(alt(ZXTRANSFORML0, ZXPROPTO));
 
 export function parseAST(expr: string): ast.ASTNode {
-  lexerPrettyPrinter(expr);
+  // lexerPrettyPrinter(expr);
   let parsed = expectEOF(ASTNODE.parse(lex.lexer.parse(expr)));
   // debugging only. should never have more than one
   if (parsed.successful && parsed.candidates.length > 1) {

--- a/src/parsing/sizes.ts
+++ b/src/parsing/sizes.ts
@@ -31,7 +31,7 @@ export function addSizes(node: ast.ASTNode): ast.ASTNode {
     case "spider": {
       node.hor_len += BASE_SIZE;
       node.ver_len += BASE_SIZE;
-      console.log("size = ", node.hor_len,", ", node.ver_len);
+      console.log("size = ", node.hor_len, ", ", node.ver_len);
       break;
     }
     case "var": {

--- a/src/parsing/sizes.ts
+++ b/src/parsing/sizes.ts
@@ -31,6 +31,7 @@ export function addSizes(node: ast.ASTNode): ast.ASTNode {
     case "spider": {
       node.hor_len += BASE_SIZE;
       node.ver_len += BASE_SIZE;
+      console.log("size = ", node.hor_len,", ", node.ver_len);
       break;
     }
     case "var": {


### PR DESCRIPTION
Changed argument extracted from information passed by lsp.
Changed rendering settings to be in new tab instead of active tab.
when new diagram is rendered, discards old diagram so as to not clutter the tab space.
when same request is made, ignores it (so continuously served lsp information is not re-rendered)
added sizing up, down, and deactivate commands.
fixed parser bug where nstack could not be embedded in stack/compose?